### PR TITLE
added botanix testnet. added extra api url for abstract-testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/abstract-testnet.json
+++ b/registry/eip155/abstract-testnet.json
@@ -11,6 +11,10 @@
     {
       "url": "https://block-explorer-api.testnet.abs.xyz/api",
       "kind": "etherscan"
+    },
+    {
+      "url": "https://api.routescan.io/v2/network/testnet/evm/11124/etherscan/api",
+      "kind": "etherscan"
     }
   ],
   "services": { "subgraphs": ["https://api.thegraph.com/deploy"] },

--- a/registry/eip155/botanix-testnet.json
+++ b/registry/eip155/botanix-testnet.json
@@ -1,0 +1,32 @@
+{
+    "id": "botanix-testnet",
+    "shortName": "Botanix",
+    "fullName": "Botanix Testnet",
+    "aliases": ["spiderchain-testnet", "spiderchain-testnet-v1", "evm-3636"],
+    "caip2Id": "eip155:3636",
+    "graphNode": { "protocol": "ethereum" },
+    "explorerUrls": ["https://testnet.botanixscan.io/"],
+    "rpcUrls": ["https://node.botanixlabs.dev"],
+    "apiUrls": [
+      { "url": "https://api.routescan.io/v2/network/testnet/evm/3636/etherscan/api", "kind": "etherscan" }
+    ],
+    "services": { "subgraphs": ["https://api.thegraph.com/deploy"] },
+    "networkType": "testnet",
+    "relations": [
+        { "kind": "testnetOf", "network": "botanix-testnet" }
+    ],
+    "issuanceRewards": false,
+    "nativeToken": "BTC",
+    "docsUrl": "https://docs.botanixlabs.xyz/",
+    "genesis": {
+      "hash": "0x3797638175875c37cefa72ef546db685e43c81ba4af8238b48a495f98d61588d",
+      "height": 0
+    },
+    "firehose": {
+      "blockType": "sf.ethereum.type.v2.Block",
+      "evmExtendedModel": false,
+      "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+      "bytesEncoding": "hex"
+    }
+  }
+  


### PR DESCRIPTION
Added new chain: botanix-testnet
Added an extra blockexplorer API url for abstract-testnet
Updated Package version: 0.6.11