### PR TITLE
added EXPchain testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/expchain-testnet.json
+++ b/registry/eip155/expchain-testnet.json
@@ -1,0 +1,32 @@
+{
+  "id": "expchain-testnet",
+  "shortName": "EXPchain",
+  "fullName": "EXPchain Testnet",
+  "aliases": ["evm-18880"],
+  "caip2Id": "eip155:18880",
+  "graphNode": { "protocol": "ethereum" },
+  "explorerUrls": ["https://blockscout-testnet.expchain.ai/"],
+  "rpcUrls": ["https://rpc1-testnet.expchain.ai"],
+  "apiUrls": [
+    {
+      "url": "https://blockscout-testnet.expchain.ai/api",
+      "kind": "blockscout"
+    }
+  ],
+  "services": { "subgraphs": ["https://api.studio.thegraph.com/deploy"] },
+  "networkType": "testnet",
+  "relations": [{ "kind": "testnetOf", "network": "expchain-testnet" }],
+  "issuanceRewards": false,
+  "nativeToken": "ZKJ",
+  "docsUrl": "https://docs.polyhedra.network/expchain",
+  "genesis": {
+    "hash": "0xcd32fbe4844c34d8c24a50949e84a2b67bacca64a1229f248bb4c8a95c5feb75",
+    "height": 0
+  },
+  "firehose": {
+    "blockType": "sf.ethereum.type.v2.Block",
+    "evmExtendedModel": false,
+    "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+    "bytesEncoding": "hex"
+  }
+}

--- a/registry/eip155/expchain-testnet.json
+++ b/registry/eip155/expchain-testnet.json
@@ -17,7 +17,7 @@
   "networkType": "testnet",
   "relations": [{ "kind": "testnetOf", "network": "expchain-testnet" }],
   "issuanceRewards": false,
-  "nativeToken": "ZKJ",
+  "nativeToken": "tZKJ",
   "docsUrl": "https://docs.polyhedra.network/expchain",
   "genesis": {
     "hash": "0xcd32fbe4844c34d8c24a50949e84a2b67bacca64a1229f248bb4c8a95c5feb75",


### PR DESCRIPTION
Added Polyhedra's EXPchain testnet. 

`bun validate` says :
> 1 Validation errors:
>   - Network expchain-testnet with CAIP-2 id eip155:18880 has different native token symbol in ethereum chain registry: tZKJ vs ZKJ

But the chain's docs say ZXJ is their native token. 