### PR TITLE
fix outdated web3icon ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.29",
+  "version": "0.6.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/kaia-testnet.json
+++ b/registry/eip155/kaia-testnet.json
@@ -25,5 +25,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "klay-token" } }
+  "icon": { "web3Icons": { "name": "kaia" } }
 }

--- a/registry/eip155/kaia.json
+++ b/registry/eip155/kaia.json
@@ -23,5 +23,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "klay-token" } }
+  "icon": { "web3Icons": { "name": "kaia" } }
 }

--- a/registry/eip155/matic.json
+++ b/registry/eip155/matic.json
@@ -48,5 +48,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "polygon-pos" } }
+  "icon": { "web3Icons": { "name": "polygon" } }
 }

--- a/registry/eip155/optimism-sepolia.json
+++ b/registry/eip155/optimism-sepolia.json
@@ -44,5 +44,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "optimistic-ethereum" } }
+  "icon": { "web3Icons": { "name": "optimism" } }
 }

--- a/registry/eip155/optimism.json
+++ b/registry/eip155/optimism.json
@@ -48,5 +48,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "optimistic-ethereum" } }
+  "icon": { "web3Icons": { "name": "optimism" } }
 }

--- a/registry/eip155/polygon-amoy.json
+++ b/registry/eip155/polygon-amoy.json
@@ -44,5 +44,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "polygon-pos" } }
+  "icon": { "web3Icons": { "name": "polygon" } }
 }

--- a/registry/eip155/viction.json
+++ b/registry/eip155/viction.json
@@ -22,5 +22,5 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "tomochain" } }
+  "icon": { "web3Icons": { "name": "viction" } }
 }

--- a/registry/eip155/zora.json
+++ b/registry/eip155/zora.json
@@ -41,5 +41,6 @@
     "evmExtendedModel": true,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
-  }
+  },
+  "icon": { "web3Icons": { "name": "zora" } }
 }


### PR DESCRIPTION
with the [latest changes](https://github.com/0xa3k5/web3icons/releases/tag/%40web3icons%2Freact%404.0.0) in web3icons, there were some breaking changes, this pr updates the necessary json files to correctly match the web3icon ids.

- [x] Use a meaningful title for the pull request
- [x] Increment `package.json` version
- [x] Pass validation checks
