### PR TITLE
feat: add icon for ultra, update schema to match the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.58",
+  "version": "0.6.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/antelope/ultra.json
+++ b/registry/antelope/ultra.json
@@ -23,5 +23,6 @@
     "blockType": "sf.antelope.type.v1.Block",
     "bufUrl": "https://buf.build/pinax/firehose-antelope",
     "bytesEncoding": "hex"
-  }
+  },
+  "icon": { "web3Icons": { "name": "ultra" } }
 }

--- a/registry/eip155/ronin.json
+++ b/registry/eip155/ronin.json
@@ -29,5 +29,6 @@
     "evmExtendedModel": false,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
-  }
+  },
+  "icon": { "web3Icons": { "name": "ronin" } }
 }

--- a/registry/eip155/zora.json
+++ b/registry/eip155/zora.json
@@ -42,5 +42,7 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
-  "icon": { "web3Icons": { "name": "zora", "variants": ["branded"] } }
+  "icon": {
+    "web3Icons": { "name": "zora", "variants": ["branded", "background"] }
+  }
 }

--- a/registry/eip155/zora.json
+++ b/registry/eip155/zora.json
@@ -43,6 +43,6 @@
     "bytesEncoding": "hex"
   },
   "icon": {
-    "web3Icons": { "name": "zora", "variants": ["branded", "background"] }
+    "web3Icons": { "name": "zora", "variants": ["branded"] }
   }
 }

--- a/schemas/registry.schema.json
+++ b/schemas/registry.schema.json
@@ -223,7 +223,10 @@
                 },
                 "variants": {
                   "type": "array",
-                  "items": { "type": "string", "pattern": "^(mono|branded)$" },
+                  "items": {
+                    "type": "string",
+                    "pattern": "^(mono|branded|background)$"
+                  },
                   "uniqueItems": true,
                   "description": "Variants of the icon, if none specified - all are available"
                 }

--- a/schemas/registry.schema.json
+++ b/schemas/registry.schema.json
@@ -225,7 +225,7 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^(mono|branded|background)$"
+                    "pattern": "^(mono|branded)$"
                   },
                   "uniqueItems": true,
                   "description": "Variants of the icon, if none specified - all are available"


### PR DESCRIPTION
- add support for `ultra` network
- add missing icon name to `ronin`
- update schema to correctly reflect all supported variants in the web3icons (added `background` variant)
- add `background` variant to `zora`

i see only the `bnb-svm` network is missing an icon, i'm not sure what this network is, tried to look up online but couldn't understand much, if someone can share a link for me I can try to add support for the icon in web3icons, although I suspect it might just be binance smart chain's icon

- [x] Use a meaningful title for the pull request
- [x] Increment `package.json` version
- [x] Pass validation checks
