### PR TITLE
Added Solana alias 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.64",
+  "version": "0.6.65",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/solana/solana-mainnet-beta.json
+++ b/registry/solana/solana-mainnet-beta.json
@@ -2,7 +2,7 @@
   "id": "solana-mainnet-beta",
   "shortName": "Solana",
   "fullName": "Solana Mainnet",
-  "aliases": ["solana-mainnet", "solana", "solana-beta"],
+  "aliases": ["solana-mainnet", "solana", "solana-beta", "sol-mainnet"],
   "caip2Id": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "explorerUrls": ["http://explorer.solana.com", "http://solana.fm"],
   "rpcUrls": ["https://api.mainnet-beta.solana.com"],


### PR DESCRIPTION
Working with substreams and they use the alias `sol-mainnet` for Solana, figured it made sense to add it here as we want to use this as source of truth.