### PR TITLE
Added TRON and TRON EVM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.68",
+  "version": "0.6.69",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/tron-evm.json
+++ b/registry/eip155/tron-evm.json
@@ -13,7 +13,7 @@
   ],
   "relations": [{ "kind": "evmOf", "network": "tron" }],
   "apiUrls": [
-    { "url": "https://apilist.tronscanapi.com/api", "kind": "etherscan" }
+  { "url": "https://apilist.tronscanapi.com/api", "kind": "other" }
   ],
   "networkType": "mainnet",
   "services": {

--- a/registry/eip155/tron-evm.json
+++ b/registry/eip155/tron-evm.json
@@ -19,8 +19,8 @@
   "services": {
     "subgraphs": [],
     "sps": [],
-    "firehose": ["mainnet.tron.streamingfast.io:443"],
-    "substreams": ["mainnet.tron.streamingfast.io:443"]
+    "firehose": ["mainnet-evm.tron.streamingfast.io:443"],
+    "substreams": ["mainnet-evm.tron.streamingfast.io:443"]
   },
   "issuanceRewards": true,
   "nativeToken": "TRX",

--- a/registry/eip155/tron-evm.json
+++ b/registry/eip155/tron-evm.json
@@ -31,7 +31,7 @@
   },
   "firehose": {
     "blockType": "sf.ethereum.type.v2.Block",
-    "evmExtendedModel": true,
+    "evmExtendedModel": false,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },

--- a/registry/eip155/tron-evm.json
+++ b/registry/eip155/tron-evm.json
@@ -1,8 +1,8 @@
 {
-  "id": "tron",
-  "shortName": "Tron",
-  "fullName": "Tron Mainnet",
-  "aliases": ["tron-mainnet"],
+  "id": "tron-evm",
+  "shortName": "TRON EVM",
+  "fullName": "TRON EVM Mainnet",
+  "aliases": ["tronevm", "tron-evm-mainnet", "evm-728126428"],
   "caip2Id": "eip155:728126428",
   "graphNode": { "protocol": "ethereum" },
   "explorerUrls": ["https://tronscan.org"],
@@ -11,6 +11,7 @@
     "https://tron.drpc.org",
     "https://rpc.ankr.com/tron_jsonrpc"
   ],
+  "relations": [{ "kind": "evmOf", "network": "tron" }],
   "apiUrls": [
     { "url": "https://apilist.tronscanapi.com/api", "kind": "etherscan" }
   ],
@@ -29,9 +30,9 @@
     "height": 0
   },
   "firehose": {
-    "blockType": "sf.tron.type.v1.Block",
-    "evmExtendedModel": false,
-    "bufUrl": "https://buf.build/streamingfast/firehose-tron",
+    "blockType": "sf.ethereum.type.v2.Block",
+    "evmExtendedModel": true,
+    "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex"
   },
   "icon": { "web3Icons": { "name": "tron" } }

--- a/registry/eip155/tron-evm.json
+++ b/registry/eip155/tron-evm.json
@@ -22,7 +22,7 @@
     "firehose": ["mainnet-evm.tron.streamingfast.io:443"],
     "substreams": ["mainnet-evm.tron.streamingfast.io:443"]
   },
-  "issuanceRewards": true,
+  "issuanceRewards": false,
   "nativeToken": "TRX",
   "docsUrl": "https://developers.tron.network",
   "genesis": {

--- a/registry/eip155/tron-evm.json
+++ b/registry/eip155/tron-evm.json
@@ -13,7 +13,7 @@
   ],
   "relations": [{ "kind": "evmOf", "network": "tron" }],
   "apiUrls": [
-  { "url": "https://apilist.tronscanapi.com/api", "kind": "other" }
+    { "url": "https://apilist.tronscanapi.com/api", "kind": "other" }
   ],
   "networkType": "mainnet",
   "services": {

--- a/registry/eip155/tron.json
+++ b/registry/eip155/tron.json
@@ -1,0 +1,38 @@
+{
+  "id": "tron",
+  "shortName": "Tron",
+  "fullName": "Tron Mainnet",
+  "aliases": ["tron-mainnet"],
+  "caip2Id": "eip155:728126428",
+  "graphNode": { "protocol": "ethereum" },
+  "explorerUrls": ["https://tronscan.org"],
+  "rpcUrls": [
+    "https://api.trongrid.io/jsonrpc",
+    "https://tron.drpc.org",
+    "https://rpc.ankr.com/tron_jsonrpc"
+  ],
+  "apiUrls": [
+    { "url": "https://apilist.tronscanapi.com/api", "kind": "etherscan" }
+  ],
+  "networkType": "mainnet",
+  "services": {
+    "subgraphs": [],
+    "sps": [],
+    "firehose": ["mainnet.tron.streamingfast.io:443"],
+    "substreams": ["mainnet.tron.streamingfast.io:443"]
+  },
+  "issuanceRewards": true,
+  "nativeToken": "TRX",
+  "docsUrl": "https://developers.tron.network",
+  "genesis": {
+    "hash": "0x00000000000000001ebf88508a03865c71d452e25f4d51194196a1d22b6653dc",
+    "height": 0
+  },
+  "firehose": {
+    "blockType": "sf.tron.type.v1.Block",
+    "evmExtendedModel": false,
+    "bufUrl": "https://buf.build/streamingfast/firehose-tron",
+    "bytesEncoding": "hex"
+  },
+  "icon": { "web3Icons": { "name": "tron" } }
+}

--- a/registry/tron/tron.json
+++ b/registry/tron/tron.json
@@ -20,7 +20,7 @@
     "firehose": ["mainnet.tron.streamingfast.io:443"],
     "substreams": ["mainnet.tron.streamingfast.io:443"]
   },
-  "issuanceRewards": true,
+  "issuanceRewards": false,
   "nativeToken": "TRX",
   "docsUrl": "https://developers.tron.network",
   "genesis": {

--- a/registry/tron/tron.json
+++ b/registry/tron/tron.json
@@ -29,7 +29,6 @@
   },
   "firehose": {
     "blockType": "sf.tron.type.v1.Block",
-    "evmExtendedModel": false,
     "bufUrl": "https://buf.build/streamingfast/firehose-tron",
     "bytesEncoding": "hex"
   },

--- a/registry/tron/tron.json
+++ b/registry/tron/tron.json
@@ -11,7 +11,7 @@
     "https://rpc.ankr.com/tron_jsonrpc"
   ],
   "apiUrls": [
-  { "url": "https://apilist.tronscanapi.com/api", "kind": "other" }
+    { "url": "https://apilist.tronscanapi.com/api", "kind": "other" }
   ],
   "networkType": "mainnet",
   "services": {

--- a/registry/tron/tron.json
+++ b/registry/tron/tron.json
@@ -3,7 +3,7 @@
   "shortName": "TRON",
   "fullName": "TRON Mainnet",
   "aliases": ["tron-mainnet"],
-  "caip2Id": "eip155:728126428",
+  "caip2Id": "tron:mainnet",
   "explorerUrls": ["https://tronscan.org"],
   "rpcUrls": [
     "https://api.trongrid.io/jsonrpc",

--- a/registry/tron/tron.json
+++ b/registry/tron/tron.json
@@ -1,0 +1,37 @@
+{
+  "id": "tron",
+  "shortName": "TRON",
+  "fullName": "TRON Mainnet",
+  "aliases": ["tron-mainnet"],
+  "caip2Id": "eip155:728126428",
+  "explorerUrls": ["https://tronscan.org"],
+  "rpcUrls": [
+    "https://api.trongrid.io/jsonrpc",
+    "https://tron.drpc.org",
+    "https://rpc.ankr.com/tron_jsonrpc"
+  ],
+  "apiUrls": [
+    { "url": "https://apilist.tronscanapi.com/api", "kind": "etherscan" }
+  ],
+  "networkType": "mainnet",
+  "services": {
+    "subgraphs": [],
+    "sps": [],
+    "firehose": ["mainnet.tron.streamingfast.io:443"],
+    "substreams": ["mainnet.tron.streamingfast.io:443"]
+  },
+  "issuanceRewards": true,
+  "nativeToken": "TRX",
+  "docsUrl": "https://developers.tron.network",
+  "genesis": {
+    "hash": "0x00000000000000001ebf88508a03865c71d452e25f4d51194196a1d22b6653dc",
+    "height": 0
+  },
+  "firehose": {
+    "blockType": "sf.tron.type.v1.Block",
+    "evmExtendedModel": false,
+    "bufUrl": "https://buf.build/streamingfast/firehose-tron",
+    "bytesEncoding": "hex"
+  },
+  "icon": { "web3Icons": { "name": "tron" } }
+}

--- a/registry/tron/tron.json
+++ b/registry/tron/tron.json
@@ -11,7 +11,7 @@
     "https://rpc.ankr.com/tron_jsonrpc"
   ],
   "apiUrls": [
-    { "url": "https://apilist.tronscanapi.com/api", "kind": "etherscan" }
+  { "url": "https://apilist.tronscanapi.com/api", "kind": "other" }
   ],
   "networkType": "mainnet",
   "services": {

--- a/src/validate_logic.ts
+++ b/src/validate_logic.ts
@@ -33,12 +33,6 @@ const ALLOWED_DUPLICATE_FIELDS_PER_NETWORK: Record<string, { field: string, netw
   "apiUrls.url": [
     { field: "apiUrls.url", networks: ["tron", "tron-evm"] },
   ],
-  "services.firehose": [
-    { field: "services.firehose", networks: ["tron", "tron-evm"] },
-  ],
-  "services.substreams": [
-    { field: "services.substreams", networks: ["tron", "tron-evm"] },
-  ]
 };
 
 const ALLOWED_EVM_CHAIN_NON_EVM_PROTOCOL: string[] = ["tron"];


### PR DESCRIPTION
Added both TRON and TRON EVM network
Since we have support for both ethereum block types and tron block types, I created 2 different networks
I added a relation object with `kind` = `evmOf` to link the TRON and TRON EVM chains together. 

I also had to modify the `validate_logic.ts` file a little bit to allow some duplications. First, it doesn't allow some of the fields to be duplicated, which makes sense, but in our case, they are the same (`genesis.hash`,`explorerUrls`, `rpcUrls`, etc.)
I also modified the check on EVM chain if there is a `caip2id` value because technically both are the same. I'm not sure if we want to allow a duplicate like this thought cause that could lead to issues if users filter by this field.