### PR TITLE
add katana firehose/substreams + extended blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/katana-tatara.json
+++ b/registry/eip155/katana-tatara.json
@@ -20,14 +20,14 @@
   "nativeToken": "ETH",
   "firehose": {
     "blockType": "sf.ethereum.type.v2.Block",
-    "evmExtendedModel": false,
+    "evmExtendedModel": true,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex",
     "firstStreamableBlock": {
       "id": "0xbca38f4936fefe65751e55b3f3f88fec27d478e283b6bb92b5268e2ffcea7716",
       "height": 0
     },
-    "blockFeatures": ["base"]
+    "blockFeatures": ["extended"]
   },
   "icon": { "web3Icons": { "name": "katana" } }
 }

--- a/registry/eip155/katana.json
+++ b/registry/eip155/katana.json
@@ -5,21 +5,25 @@
   "aliases": ["evm-747474", "katana-mainnet"],
   "caip2Id": "eip155:747474",
   "graphNode": { "protocol": "ethereum" },
-  "services": { "subgraphs": ["https://api.studio.thegraph.com/deploy"] },
+  "services": {
+    "subgraphs": ["https://api.studio.thegraph.com/deploy"],
+    "firehose": ["katana.streamingfast.io:443"],
+    "substreams": ["katana.streamingfast.io:443"]
+  },
   "networkType": "mainnet",
   "relations": [{ "kind": "l2Of", "network": "mainnet" }],
   "issuanceRewards": false,
   "nativeToken": "ETH",
   "firehose": {
     "blockType": "sf.ethereum.type.v2.Block",
-    "evmExtendedModel": false,
+    "evmExtendedModel": true,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex",
     "firstStreamableBlock": {
       "id": "0x2d28253bc3362fb71336e4f45ba058a24167ef8f43aa2527d5ed9ecfa1d2d3d6",
       "height": 0
     },
-    "blockFeatures": ["base"]
+    "blockFeatures": ["extended"]
   },
   "icon": { "web3Icons": { "name": "katana" } }
 }


### PR DESCRIPTION
When adding or updating a chain follow the [README](./README.md).

- [x] Use a meaningful title for the pull request
- [x] Pass validation checks


NOTE: I had to set the testnet (tatara) to 'extended' blocks too, to pass the `bun` validations, even if no one is currently producing or indexing with extended firehose blocks on the testnet

