### PR TITLE
Add inj evm mainnet

### DIFF
--- a/registry/eip155/injective-evm-testnet.json
+++ b/registry/eip155/injective-evm-testnet.json
@@ -22,6 +22,7 @@
     "firehose": ["testnet.injective-evm.streamingfast.io:443"]
   },
   "networkType": "testnet",
+  "relations": [{ "kind": "testnetOf", "network": "injective-evm" }],
   "issuanceRewards": false,
   "nativeToken": "INJ",
   "docsUrl": "https://docs.injective.network/developers-evm/network-information",

--- a/registry/eip155/injective-evm.json
+++ b/registry/eip155/injective-evm.json
@@ -1,16 +1,14 @@
 {
-  "id": "injective-evm-mainnet",
+  "id": "injective-evm",
   "shortName": "Injective EVM",
   "fullName": "Injective EVM Mainnet",
-  "aliases": ["evm-1776"],
+  "aliases": ["evm-1776", "injective-evm-mainnet"],
   "caip2Id": "eip155:1776",
   "graphNode": { "protocol": "ethereum" },
   "explorerUrls": ["https://blockscout.injective.network"],
   "rpcUrls": [
     "https://sentry.evm-rpc.injective.network",
-    "wss://sentry.evm-ws.injective.network",
-    "https://injectiveevm-rpc.polkachu.com",
-    "wss://injectiveevm-ws.polkachu.com"
+    "https://injectiveevm-rpc.polkachu.com"
   ],
   "apiUrls": [
     { "url": "https://blockscout-api.injective.network/api", "kind": "blockscout" }
@@ -19,7 +17,7 @@
     "substreams": ["mainnet.injective-evm.streamingfast.io:443"],
     "firehose": ["mainnet.injective-evm.streamingfast.io:443"]
   },
-  "networkType": "testnet",
+  "networkType": "mainnet",
   "issuanceRewards": false,
   "nativeToken": "INJ",
   "docsUrl": "https://docs.injective.network/developers-evm/network-information",
@@ -28,7 +26,7 @@
     "evmExtendedModel": true,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex",
-    
+
     "firstStreamableBlock": {
       "id": "0xa217fa3285f9af1e8a27b79d5c276241ad46ec88eb57fd6cb0137b25d90ff8cf",
       "height": 138091500

--- a/src/validate_logic.ts
+++ b/src/validate_logic.ts
@@ -16,7 +16,6 @@ const ALLOWED_DUPLICATES: string[] = [
 
 const ALLOWED_ETHEREUM_LIST_MISSING: string[] = [
   "ozean-poseidon",
-  "injective-evm-testnet",
   "autonomys",
   "autonomys-chronos",
   "sonic-testnet",


### PR DESCRIPTION
Add Injective EVM to Network Registry. 
This is as of block 138091500
Injective is providing us with a snapshot to backfill the first part of the chain. Expected to be backfilled within a couple of weeks. But for now, users would need access to it.