### PR TITLE
Remove Arbitrum Nova endpoints from Pinax/EOS Nation

### DIFF
--- a/registry/eip155/arbitrum-nova.json
+++ b/registry/eip155/arbitrum-nova.json
@@ -8,15 +8,14 @@
   "explorerUrls": [],
   "rpcUrls": [
     "https://nova.arbitrum.io/rpc",
-    "https://arbitrum-nova.publicnode.com",
-    "https://arbnova.rpc.service.pinax.network"
+    "https://arbitrum-nova.publicnode.com"
   ],
   "apiUrls": [],
   "services": {
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
     "sps": [],
-    "firehose": ["arbnova.firehose.pinax.network:443"],
-    "substreams": ["arbnova.substreams.pinax.network:443"]
+    "firehose": [],
+    "substreams": []
   },
   "networkType": "mainnet",
   "relations": [{ "kind": "l2Of", "network": "mainnet" }],


### PR DESCRIPTION
- remove arbitrum nova endpoints from Pinax/EOS Nation
