### PR TITLE
Remove chiado cl from pinax service

### DIFF
--- a/registry/beacon/gnosis-chiado-cl.json
+++ b/registry/beacon/gnosis-chiado-cl.json
@@ -10,8 +10,8 @@
   "networkType": "beacon",
   "relations": [{ "kind": "beaconOf", "network": "gnosis-chiado" }],
   "services": {
-    "firehose": ["chiado-cl.firehose.pinax.network:443"],
-    "substreams": ["chiado-cl.substreams.pinax.network:443"]
+    "firehose": [""],
+    "substreams": [""]
   },
   "issuanceRewards": false,
   "nativeToken": "XDAI",

--- a/registry/beacon/gnosis-chiado-cl.json
+++ b/registry/beacon/gnosis-chiado-cl.json
@@ -10,8 +10,8 @@
   "networkType": "beacon",
   "relations": [{ "kind": "beaconOf", "network": "gnosis-chiado" }],
   "services": {
-    "firehose": [""],
-    "substreams": [""]
+    "firehose": [],
+    "substreams": []
   },
   "issuanceRewards": false,
   "nativeToken": "XDAI",


### PR DESCRIPTION
This pull request makes a small change to the `registry/beacon/gnosis-chiado-cl.json` file. The endpoints for the `firehose` and `substreams` services have been cleared, replacing their URLs with empty strings.