### PR TITLE
remove telos and telostest endpoint from pinax service

### DIFF
--- a/registry/antelope/telos-testnet.json
+++ b/registry/antelope/telos-testnet.json
@@ -10,8 +10,8 @@
   "networkType": "testnet",
   "relations": [{ "kind": "testnetOf", "network": "telos" }],
   "services": {
-    "firehose": ["telostest.firehose.pinax.network:443"],
-    "substreams": ["telostest.substreams.pinax.network:443"]
+    "firehose": [],
+    "substreams": []
   },
   "issuanceRewards": false,
   "nativeToken": "TELOS",

--- a/registry/antelope/telos.json
+++ b/registry/antelope/telos.json
@@ -9,8 +9,8 @@
   "apiUrls": [],
   "networkType": "mainnet",
   "services": {
-    "firehose": ["telos.firehose.pinax.network:443"],
-    "substreams": ["telos.substreams.pinax.network:443"]
+    "firehose": [],
+    "substreams": []
   },
   "issuanceRewards": false,
   "nativeToken": "TELOS",


### PR DESCRIPTION
This pull request removes the `firehose` and `substreams` service endpoints from both the Telos mainnet and testnet registry files. This change likely reflects that these services are no longer available or should not be listed for these networks.

**Service endpoint removals:**

* Removed all `firehose` and `substreams` service endpoints from the `services` section in `telos.json` (mainnet).
* Removed all `firehose` and `substreams` service endpoints from the `services` section in `telos-testnet.json` (testnet).