### PR TITLE
Remove near neartest endpoint from Pinax service

### DIFF
--- a/registry/antelope/telos-testnet.json
+++ b/registry/antelope/telos-testnet.json
@@ -10,8 +10,8 @@
   "networkType": "testnet",
   "relations": [{ "kind": "testnetOf", "network": "telos" }],
   "services": {
-    "firehose": ["telostest.firehose.pinax.network:443"],
-    "substreams": ["telostest.substreams.pinax.network:443"]
+    "firehose": [],
+    "substreams": []
   },
   "issuanceRewards": false,
   "nativeToken": "TELOS",

--- a/registry/antelope/telos.json
+++ b/registry/antelope/telos.json
@@ -9,8 +9,8 @@
   "apiUrls": [],
   "networkType": "mainnet",
   "services": {
-    "firehose": ["telos.firehose.pinax.network:443"],
-    "substreams": ["telos.substreams.pinax.network:443"]
+    "firehose": [],
+    "substreams": []
   },
   "issuanceRewards": false,
   "nativeToken": "TELOS",

--- a/registry/near/near-mainnet.json
+++ b/registry/near/near-mainnet.json
@@ -13,11 +13,9 @@
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
     "sps": [],
     "firehose": [
-      "near.firehose.pinax.network:443",
       "mainnet.near.streamingfast.io:443"
     ],
     "substreams": [
-      "near.substreams.pinax.network:443",
       "mainnet.near.streamingfast.io:443"
     ]
   },

--- a/registry/near/near-testnet.json
+++ b/registry/near/near-testnet.json
@@ -14,11 +14,9 @@
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
     "sps": [],
     "firehose": [
-      "neartest.firehose.pinax.network:443",
       "testnet.near.streamingfast.io:443"
     ],
     "substreams": [
-      "neartest.substreams.pinax.network:443",
       "testnet.near.streamingfast.io:443"
     ]
   },


### PR DESCRIPTION
## Remove near and near-testnet endpoints from pinax service

Removes the near and near-testnet network endpoints from the pinax service configuration.

## Changes
- Removed near endpoint from `registry/near/near-mainnet.json`
- Removed near-testnet endpoint from `registry/near/near-testnet.json`
