### PR TITLE
Add pinax service endpoints (firehose, substreams, rpc) for xlayer

### DIFF
--- a/registry/eip155/xlayer-mainnet.json
+++ b/registry/eip155/xlayer-mainnet.json
@@ -6,8 +6,16 @@
   "caip2Id": "eip155:196",
   "graphNode": { "protocol": "ethereum" },
   "explorerUrls": ["https://www.oklink.com/xlayer"],
-  "rpcUrls": ["https://rpc.xlayer.tech", "https://xlayerrpc.okx.com"],
-  "services": { "subgraphs": ["https://api.studio.thegraph.com/deploy"] },
+  "rpcUrls": [
+    "https://rpc.xlayer.tech",
+    "https://xlayerrpc.okx.com",
+    "https://xlayer.rpc.service.pinax.network"
+  ],
+  "services": {
+    "subgraphs": ["https://api.studio.thegraph.com/deploy"],
+    "firehose": ["xlayer.firehose.pinax.network:443"],
+    "substreams": ["xlayer.substreams.pinax.network:443"]
+  },
   "networkType": "mainnet",
   "relations": [{ "kind": "l2Of", "network": "mainnet" }],
   "issuanceRewards": false,


### PR DESCRIPTION
## Add pinax service endpoints for X Layer

Adds firehose, substreams, and RPC service endpoints from pinax to the X Layer network configuration.

## Changes
- Added pinax RPC endpoint: `https://xlayer.rpc.service.pinax.network`
- Added pinax Firehose endpoint: `xlayer.firehose.pinax.network:443`
- Added pinax Substreams endpoint: `xlayer.substreams.pinax.network:443`