### PR TITLE
Remove near and near-testnet endpoint from pinax service

### DIFF
--- a/registry/near/near-mainnet.json
+++ b/registry/near/near-mainnet.json
@@ -13,11 +13,9 @@
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
     "sps": [],
     "firehose": [
-      "near.firehose.pinax.network:443",
       "mainnet.near.streamingfast.io:443"
     ],
     "substreams": [
-      "near.substreams.pinax.network:443",
       "mainnet.near.streamingfast.io:443"
     ]
   },

--- a/registry/near/near-testnet.json
+++ b/registry/near/near-testnet.json
@@ -14,11 +14,9 @@
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
     "sps": [],
     "firehose": [
-      "neartest.firehose.pinax.network:443",
       "testnet.near.streamingfast.io:443"
     ],
     "substreams": [
-      "neartest.substreams.pinax.network:443",
       "testnet.near.streamingfast.io:443"
     ]
   },


### PR DESCRIPTION
## Remove near and near-testnet endpoints from pinax service

Removes the pinax firehose and substreams endpoints from NEAR mainnet and testnet, keeping only the streamingfast endpoints.

## Changes
- Removed `near.firehose.pinax.network:443` from near-mainnet.json
- Removed `near.substreams.pinax.network:443` from near-mainnet.json
- Removed `neartest.firehose.pinax.network:443` from near-testnet.json
- Removed `neartest.substreams.pinax.network:443` from near-testnet.json
- Retained streamingfast endpoints as primary service providers