### PR TITLE
Add pinax service endpoints (firehose, substreams, rpc) for linea

### DIFF
--- a/registry/eip155/linea.json
+++ b/registry/eip155/linea.json
@@ -8,7 +8,8 @@
   "explorerUrls": ["https://lineascan.build"],
   "rpcUrls": [
     "https://rpc.linea.build",
-    "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}"
+    "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}",
+    "https://linea.rpc.service.pinax.network"
   ],
   "apiUrls": [
     { "url": "https://linea.abi.pinax.network/api", "kind": "etherscan" },
@@ -16,8 +17,8 @@
   ],
   "services": {
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
-    "firehose": [],
-    "substreams": []
+    "firehose": ["linea.firehose.pinax.network:443"],
+    "substreams": ["linea.substreams.pinax.network:443"]
   },
   "networkType": "mainnet",
   "relations": [{ "kind": "l2Of", "network": "mainnet" }],


### PR DESCRIPTION
## Add pinax service endpoints for Linea

Adds firehose, substreams, and RPC service endpoints from pinax to the Linea network configuration.

## Changes
- Added pinax RPC endpoint: `https://linea.rpc.service.pinax.network`
- Added pinax Firehose endpoint: `linea.firehose.pinax.network:443`
- Added pinax Substreams endpoint: `linea.substreams.pinax.network:443`