### PR TITLE
Add pinax service endpoints for Linea Sepolia

### DIFF
--- a/registry/eip155/linea-sepolia.json
+++ b/registry/eip155/linea-sepolia.json
@@ -7,7 +7,10 @@
   "caip2Id": "eip155:59141",
   "graphNode": { "protocol": "ethereum" },
   "explorerUrls": ["https://sepolia.lineascan.build"],
-  "rpcUrls": ["https://rpc.sepolia.linea.build"],
+  "rpcUrls": [
+    "https://rpc.sepolia.linea.build",
+    "https://linea-sepolia.rpc.service.pinax.network"
+  ],
   "apiUrls": [
     {
       "url": "https://linea-sepolia.abi.pinax.network/api",
@@ -20,8 +23,8 @@
   ],
   "services": {
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
-    "firehose": [],
-    "substreams": []
+    "firehose": ["linea-sepolia.firehose.pinax.network:443"],
+    "substreams": ["linea-sepolia.substreams.pinax.network:443"]
   },
   "networkType": "testnet",
   "relations": [

--- a/registry/eip155/linea-sepolia.json
+++ b/registry/eip155/linea-sepolia.json
@@ -9,7 +9,7 @@
   "explorerUrls": ["https://sepolia.lineascan.build"],
   "rpcUrls": [
     "https://rpc.sepolia.linea.build",
-    "https://linea-sepolia.rpc.service.pinax.network"
+    "https://lineasepolia.rpc.service.pinax.network"
   ],
   "apiUrls": [
     {
@@ -23,8 +23,8 @@
   ],
   "services": {
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
-    "firehose": ["linea-sepolia.firehose.pinax.network:443"],
-    "substreams": ["linea-sepolia.substreams.pinax.network:443"]
+    "firehose": ["lineasepolia.firehose.pinax.network:443"],
+    "substreams": ["lineasepolia.substreams.pinax.network:443"]
   },
   "networkType": "testnet",
   "relations": [


### PR DESCRIPTION
Adds firehose, substreams, and RPC service endpoints from pinax to the Linea Sepolia testnet configuration.

## Changes
- Added pinax RPC endpoint: `https://lineasepolia.rpc.service.pinax.network`
- Added pinax Firehose endpoint: `lineasepolia.firehose.pinax.network:443`
- Added pinax Substreams endpoint: `lineasepolia.substreams.pinax.network:443`