### PR TITLE
Remove StreamingFast Firehose & Substreams support on Sei

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.89",
+  "version": "0.7.90",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/sei-mainnet.json
+++ b/registry/eip155/sei-mainnet.json
@@ -12,9 +12,7 @@
     { "url": "https://seitrace.com/pacific-1/api", "kind": "etherscan" }
   ],
   "services": {
-    "subgraphs": ["https://api.studio.thegraph.com/deploy"],
-    "firehose": ["evm-mainnet.sei.streamingfast.io:443"],
-    "substreams": ["evm-mainnet.sei.streamingfast.io:443"]
+    "subgraphs": ["https://api.studio.thegraph.com/deploy"]
   },
   "networkType": "mainnet",
   "issuanceRewards": false,


### PR DESCRIPTION
Removed firehose and substreams services from sei-mainnet.json.

When adding or updating a chain follow the [README](./README.md).

- [ ] Use a meaningful title for the pull request
- [ ] Pass validation checks
