### PR TITLE
Updated stellar-mainnet first streamable block

### DIFF
--- a/registry/stellar/stellar.json
+++ b/registry/stellar/stellar.json
@@ -21,8 +21,8 @@
     "bufUrl": "https://buf.build/streamingfast/firehose-stellar",
     "bytesEncoding": "base64",
     "firstStreamableBlock": {
-      "id": "0x84e2b18c296badee2a6c30347911f2b5a4323e1ecb3c8986235e1fdc322dadbe",
-      "height": 55411000
+      "id": "0xec168d452542589dbc2d0eb6d58c74b9bb2ccb93bba879a3b3fa73fdfa730182",
+      "height": 3
     }
   },
   "icon": { "web3Icons": { "name": "stellar" } }


### PR DESCRIPTION
First streamable block for `stellar-mainnet` is actually 3.

- [X] Use a meaningful title for the pull request
- [X] Pass validation checks
