### PR TITLE
fix(mainnet): update etherscan api url to thegraph.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.95",
+  "version": "0.7.96",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/mainnet.json
+++ b/registry/eip155/mainnet.json
@@ -13,7 +13,7 @@
     "https://mainnet.infura.io/v3/{INFURA_API_KEY}"
   ],
   "apiUrls": [
-    { "url": "https://mainnet.abi.pinax.network/api", "kind": "etherscan" },
+    { "url": "https://mainnet.abi.thegraph.com/api", "kind": "etherscan" },
     { "url": "https://eth.blockscout.com/api", "kind": "blockscout" },
     {
       "url": "https://api.routescan.io/v2/network/mainnet/evm/1/etherscan/api",


### PR DESCRIPTION
- replace mainnet.abi.pinax.network/api with mainnet.abi.thegraph.com/api

When adding or updating a chain follow the [README](./README.md).

- [ ] Use a meaningful title for the pull request
- [ ] Pass validation checks
