### PR TITLE
feat(eip155): add XDC Network (50) and XDC Apothem testnet (51)

### DIFF
--- a/registry/eip155/xdc-testnet.json
+++ b/registry/eip155/xdc-testnet.json
@@ -1,0 +1,20 @@
+{
+  "id": "xdc-testnet",
+  "shortName": "XDC",
+  "secondName": "Apothem",
+  "fullName": "XDC Apothem Testnet",
+  "aliases": ["xinfin-apothem", "apothem", "xdc-apothem", "evm-51"],
+  "caip2Id": "eip155:51",
+  "graphNode": { "protocol": "ethereum" },
+  "explorerUrls": ["https://testnet.xdcscan.com"],
+  "apiUrls": [
+    { "url": "https://api.etherscan.io/v2/api?chainid=51", "kind": "etherscan" }
+  ],
+  "rpcUrls": ["https://erpc.apothem.network"],
+  "networkType": "testnet",
+  "relations": [{ "kind": "testnetOf", "network": "xdc" }],
+  "services": { "subgraphs": [] },
+  "issuanceRewards": false,
+  "nativeToken": "TXDC",
+  "docsUrl": "https://docs.xdc.network"
+}

--- a/registry/eip155/xdc.json
+++ b/registry/eip155/xdc.json
@@ -1,0 +1,18 @@
+{
+  "id": "xdc",
+  "shortName": "XDC",
+  "fullName": "XDC Network",
+  "aliases": ["xinfin", "xdc-mainnet", "evm-50"],
+  "caip2Id": "eip155:50",
+  "graphNode": { "protocol": "ethereum" },
+  "explorerUrls": ["https://xdcscan.com"],
+  "apiUrls": [
+    { "url": "https://api.etherscan.io/v2/api?chainid=50", "kind": "etherscan" }
+  ],
+  "rpcUrls": ["https://rpc.xdc.org"],
+  "networkType": "mainnet",
+  "services": { "subgraphs": [] },
+  "issuanceRewards": false,
+  "nativeToken": "XDC",
+  "docsUrl": "https://docs.xdc.network"
+}


### PR DESCRIPTION
## Summary

Adds **XDC Network** mainnet (`eip155:50`) and **XDC Apothem** testnet (`eip155:51`) to the registry under `registry/eip155/`.

XDC is an EVM-compatible L1 (XDPoS consensus). Both chains are present in `ethereum-lists/chains` and on the **Etherscan V2** unified API, and both support **EIP-1559**. Entries follow the same metadata-only shape as the 54 existing service-less networks (e.g. `metis`, `aurora`, `vana`) — `services.subgraphs` is left empty pending Graph indexing support, so this is purely additive chain metadata.

## Files
- `registry/eip155/xdc.json` — XDC Network (mainnet 50)
- `registry/eip155/xdc-testnet.json` — XDC Apothem (testnet 51), `testnetOf` → `xdc`

## Validation
`bun validate` passes (schema + logic) with **0 errors**. The only output is the standard "has no web3icon" warning (shared by existing entries like `xlayer-sepolia`); a web3icon can be wired up once XDC lands in `web3icons`.

## Notes
- explorer: `xdcscan.com` / `testnet.xdcscan.com` (Etherscan V2)
- apiUrls use the Etherscan V2 form `api.etherscan.io/v2/api?chainid=50|51`
- native token: `XDC` / `TXDC`
