### PR TITLE
Add StreamingFast as Hoodi firehose & substreams provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.107",
+  "version": "0.7.108",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/hoodi.json
+++ b/registry/eip155/hoodi.json
@@ -19,8 +19,14 @@
   ],
   "services": {
     "subgraphs": ["https://api.studio.thegraph.com/deploy"],
-    "firehose": ["hoodi.firehose.pinax.network:443"],
-    "substreams": ["hoodi.substreams.pinax.network:443"]
+    "firehose": [
+      "hoodi.firehose.pinax.network:443",
+      "hoodi.eth.streamingfast.io:443"
+    ],
+    "substreams": [
+      "hoodi.substreams.pinax.network:443",
+      "hoodi.eth.streamingfast.io:443"
+    ]
   },
   "issuanceRewards": false,
   "nativeToken": "ETH",


### PR DESCRIPTION
Adds `hoodi.eth.streamingfast.io:443` as a second provider for both the Firehose and Substreams services on Ethereum Hoodi, alongside the existing Pinax endpoints.

Endpoint reachability confirmed before listing:

```
timeout 5 bash -c 'echo > /dev/tcp/hoodi.eth.streamingfast.io/443'  # OPEN
```

Checklist from the PR template:

- [x] Use a meaningful title for the pull request
- [x] Pass validation checks (`bun validate` — 0 errors; remaining warnings are pre-existing and unrelated to `hoodi`)
- [x] `bun format` run, no changes to the edited file
- [x] No `package.json` version bump (CI handles it on merge)