### PR TITLE
Add pinax service endpoints (firehose, substreams, rpc) for ink

### DIFF
--- a/registry/eip155/ink-sepolia.json
+++ b/registry/eip155/ink-sepolia.json
@@ -28,14 +28,14 @@
   "docsUrl": "https://docs.inkonchain.com",
   "firehose": {
     "blockType": "sf.ethereum.type.v2.Block",
-    "evmExtendedModel": false,
+    "evmExtendedModel": true,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex",
     "firstStreamableBlock": {
       "id": "0xe5fd5cf0be56af58ad5751b401410d6b7a09d830fa459789746a3d0dd1c79834",
       "height": 0
     },
-    "blockFeatures": ["base"]
+    "blockFeatures": ["extended"]
   },
   "icon": { "web3Icons": { "name": "ink" } }
 }

--- a/registry/eip155/ink.json
+++ b/registry/eip155/ink.json
@@ -11,24 +11,29 @@
   ],
   "rpcUrls": [
     "https://rpc-gel.inkonchain.com",
+    "https://ink.rpc.service.pinax.network",
     "https://ink.drpc.org",
     "https://ink.api.pocket.network"
   ],
-  "services": { "subgraphs": [] },
+  "services": {
+    "subgraphs": [],
+    "substreams": ["ink.substreams.pinax.network:443"],
+    "firehose": ["ink.firehose.pinax.network:443"]
+  },
   "networkType": "mainnet",
   "issuanceRewards": false,
   "nativeToken": "ETH",
   "docsUrl": "https://docs.inkonchain.com",
   "firehose": {
     "blockType": "sf.ethereum.type.v2.Block",
-    "evmExtendedModel": false,
+    "evmExtendedModel": true,
     "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
     "bytesEncoding": "hex",
     "firstStreamableBlock": {
       "id": "0x23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee",
       "height": 0
     },
-    "blockFeatures": ["base"]
+    "blockFeatures": ["extended"]
   },
   "icon": { "web3Icons": { "name": "ink" } }
 }


### PR DESCRIPTION
## Add pinax service endpoints for Ink

Adds firehose, substreams, and RPC service endpoints from pinax to the Ink network configuration.

## Changes
- Added pinax RPC endpoint: `https://ink.rpc.service.pinax.network`
- Added pinax Firehose endpoint: `ink.firehose.pinax.network:443`
- Added pinax Substreams endpoint: `ink.substreams.pinax.network:443`
- Set `evmExtendedModel: true` and `blockFeatures: ["extended"]` on `ink.json`
- Set the same on `ink-sepolia.json` (required by the testnet/mainnet parity check — see below)

No ABI endpoint is listed: `ink.abi.pinax.network` returns an empty body rather than serving the chain, so the Blockscout `/api` entry stays as the only `apiUrls` value.

## On the block model

Both pinax endpoints report `blockFeatures: ["extended"]`:

```
$ grpcurl -d '{}' ink.firehose.pinax.network:443 sf.firehose.v2.EndpointInfo/Info
{
  "chainName": "ink",
  "firstStreamableBlockId": "23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee",
  "blockIdEncoding": "BLOCK_ID_ENCODING_HEX",
  "blockFeatures": ["extended"]
}
```

`ink.substreams.pinax.network:443` returns the same, and the `firstStreamableBlockId` matches the value already on file.

This **reverts the ink portion of #239**, which set the chain to base-only. That sweep normalised `evmExtendedModel` against each chain's declared `blockFeatures` rather than against what the endpoints actually serve, so ink was brought down to `base` while its firehose was serving `extended`. Flagging it explicitly rather than quietly changing it back — happy to be corrected if the intent was that ink should be consumed as base-only regardless of what the endpoint advertises.

For comparison, on chains I checked the registry and the endpoints agree: `megaeth` is `base` in both, `base` is `extended` in both.

## On `ink-sepolia`

`validate_logic.ts` compares `blockType`, `bytesEncoding` and `evmExtendedModel` between a testnet and its mainnet, so marking ink extended is a validation error unless `ink-sepolia` matches. It is changed for that reason only.

Worth noting: no provider currently serves an ink-sepolia firehose (`services.firehose` is absent), so that block is descriptive rather than measured — I set it to match ink because they are the same OP-stack EVM chain family and the rule requires one block model per pair. If you would rather ink-sepolia stayed as-is, I can drop the `extended` change from this PR entirely and raise it separately.

## Validation

- [x] `bun validate` — zero errors (the 14 warnings are pre-existing and unrelated to ink)
- [x] `bun format` — clean
- [x] `package.json` version untouched
