### PR TITLE
Add Whitechain Sepolia (eip155:1874)

### DIFF
--- a/registry/eip155/whitechain-sepolia.json
+++ b/registry/eip155/whitechain-sepolia.json
@@ -1,0 +1,34 @@
+{
+  "id": "whitechain-sepolia",
+  "shortName": "Whitechain",
+  "secondName": "Sepolia",
+  "fullName": "Whitechain Sepolia",
+  "aliases": ["evm-1874", "wch-sepolia"],
+  "caip2Id": "eip155:1874",
+  "graphNode": { "protocol": "ethereum" },
+  "explorerUrls": ["https://explorer.testnet.whitechain.io"],
+  "apiUrls": [
+    {
+      "url": "https://explorer.testnet.whitechain.io/api",
+      "kind": "blockscout"
+    }
+  ],
+  "rpcUrls": ["https://rpc.testnet.whitechain.io"],
+  "services": { "subgraphs": [] },
+  "networkType": "testnet",
+  "relations": [{ "kind": "l2Of", "network": "sepolia" }],
+  "issuanceRewards": false,
+  "nativeToken": "WBT",
+  "docsUrl": "https://docs.whitechain.io",
+  "firehose": {
+    "blockType": "sf.ethereum.type.v2.Block",
+    "evmExtendedModel": false,
+    "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+    "bytesEncoding": "hex",
+    "firstStreamableBlock": {
+      "id": "0xb92575f4a11271b5fe065eb8289be17906302e1c23218c5a67c2871a99e6f0d5",
+      "height": 0
+    },
+    "blockFeatures": ["base"]
+  }
+}


### PR DESCRIPTION
Adds `whitechain-sepolia` (`eip155:1874`), the Whitechain testnet. It is an OP Stack (Bedrock) L2 that settles on Ethereum Sepolia and uses **WBT** as its native gas token rather than ETH.

- [x] Use a meaningful title for the pull request
- [x] Pass validation checks

### Values and how they were verified

Every value was checked against a live source rather than taken from documentation.

| Field | Value | Verified by |
| --- | --- | --- |
| `caip2Id` | `eip155:1874` | `eth_chainId` on `https://rpc.testnet.whitechain.io` returns `0x752` |
| `firehose.firstStreamableBlock.id` | `0xb92575f4a11271b5fe065eb8289be17906302e1c23218c5a67c2871a99e6f0d5` | `eth_getBlockByNumber` at `0x0` |
| `explorerUrls` / `apiUrls` | `https://explorer.testnet.whitechain.io` | `/api/v2/stats` returns a Blockscout stats payload, so the API is registered as `kind: "blockscout"` |
| `docsUrl` | `https://docs.whitechain.io` | live, and matches the `infoURL` in the ethereum-lists entry |
| `nativeToken` | `WBT` | matches `nativeCurrency` in `ethereum-lists/chains/_data/chains/eip155-1874.json` |
| `relations` | `l2Of: sepolia` | the ethereum-lists entry declares `parent: { type: "L2", chain: "eip155-11155111" }`; confirmed on-chain, the L2 bridge and messenger predeploys resolve to L1 contracts on Sepolia |

`bun validate` reports **no errors**. Two warnings, both intentional, explained below.

### Warning 1: no mainnet relation

`docs.whitechain.io` states that the OP Stack Whitechain is currently available on testnet with mainnet planned. The OP Stack mainnet is therefore not launched yet and there is nothing to point a `testnetOf` relation at.

Note that `eip155:1875` ("Whitechain") already exists as a separate, older L1: I probed it and it has no OP Stack predeploys at `0x4200…0010` or `0x4200…0015`, and it produces 2000ms blocks against this chain's 1000ms. Declaring `testnetOf: whitechain` would therefore assert a relationship that does not hold architecturally, so it is deliberately omitted. It can be added once the OP Stack mainnet ships. `arc-testnet`, `polkadot-testnet` and `status-sepolia` carry the same warning today.

### Warning 2: no web3icon

There is no `whitechain` icon in the web3icons repo yet (checked `whitechain`, `white-chain`, `whitebit` and `wbt` – all 404). Per the contributor guidance, the `icon` field is omitted rather than pointed at a name that does not exist, which would be a hard error.

### Note on the RPC endpoint

`https://rpc.testnet.whitechain.io` is the only public RPC for this chain and it is **not an archive node**. `eth_getBalance` succeeds at roughly `latest-10000` but fails with `state at block #N is pruned` by `latest-50000`, so it retains on the order of hours of state at 1s block times.

I have listed it anyway because it is the canonical endpoint and omitting `rpcUrls` produces its own warning, but flagging it explicitly since the repo expects `rpcUrls` to be archive nodes. Happy to drop it if you would rather the field stay archive-only.

### Not included

No Graph service endpoints are claimed. `services` is `{ "subgraphs": [] }`. I confirmed that `https://whitechain-sepolia.abi.thegraph.com/api` returns HTTP 400 for this chain, so no ABI endpoint is listed either.

Per `AGENTS.md` the version in `package.json` is left alone for CI to bump on merge.
