### PR TITLE
Add StreamingFast Robinhood mainnet endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.118",
+  "version": "0.7.119",
   "private": true,
   "type": "module",
   "scripts": {

--- a/registry/eip155/robinhood.json
+++ b/registry/eip155/robinhood.json
@@ -10,10 +10,12 @@
     "subgraphs": [],
     "substreams": [
       "robinhood.substreams.pinax.network:443",
+      "mainnet.robinhood.streamingfast.io:443",
       "robinhood.substreams.data.nexus:443"
     ],
     "firehose": [
       "robinhood.firehose.pinax.network:443",
+      "mainnet.robinhood.streamingfast.io:443",
       "robinhood.firehose.data.nexus:443"
     ]
   },


### PR DESCRIPTION
Adds `mainnet.robinhood.streamingfast.io:443` as a Firehose and Substreams provider for `robinhood` (eip155:4663), alongside the existing Pinax and Nexus endpoints.

- [x] Use a meaningful title for the pull request
- [x] Pass validation checks